### PR TITLE
Update checked R versions

### DIFF
--- a/.github/workflows/phs_R-CMD-check.yaml
+++ b/.github/workflows/phs_R-CMD-check.yaml
@@ -29,13 +29,10 @@ jobs:
           - {os: ubuntu-latest, r: 'oldrel-2'}
 
           # An approximation for the PHS RStudio Desktop installation
-          - {os: windows-latest, r: '3.6.1'}
-          - {os: windows-latest, r: '4.0.1'}
+          - {os: windows-latest, r: '4.4.1'}
 
           # An approximation of the PHS RStudio setup on the Posit Workbench
-          - {os: ubuntu-latest, r: '3.6.1'}
-          - {os: ubuntu-latest, r: '4.0.2'}
-          - {os: ubuntu-latest, r: '4.1.2'}
+          - {os: ubuntu-latest, r: '4.4.2'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Removed checks on old R versions, we now only check on:
 - The latest version (Windows, Mac and Linux)
 - The in-development version (Windows and Linux)
 - The previous 2 versions (Linux)
 - The version used in PHS RStudio Desktop - 4.4.1
 - The version used in the *new* PHS Posit Workbench - 4.4.2