### PR TITLE
Limit concurrency of jobs by cancelling or queueing as appropriate

### DIFF
--- a/.github/workflows/phs_R-CMD-check.yaml
+++ b/.github/workflows/phs_R-CMD-check.yaml
@@ -40,8 +40,7 @@ jobs:
 
           # An approximation of the PHS RStudio setup on the Posit Workbench
           - {os: ubuntu-latest, r: '4.4.2'}
-      ${{ if inputs.limit_parallel == true }}:
-        max-parallel: 3
+        max-parallel: ${{ inputs.limit_parallel == true && 3 || null }}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/phs_R-CMD-check.yaml
+++ b/.github/workflows/phs_R-CMD-check.yaml
@@ -18,6 +18,19 @@ env:
   MAX_PARALLEL:  ${{ inputs.limit_parallel == false &&  10 || 3 }}
   
 jobs:
+  set-max-parallel:
+    runs-on: ubuntu-latest
+    outputs:
+      max-parallel: ${{ steps.set-max-parallel.outputs.max-parallel }}
+    steps:
+      - id: set-max-parallel
+        run: |
+          if [ "${{ inputs.limit_parallel }}" == "true" ]; then
+            echo "max-parallel=3" >> $GITHUB_OUTPUT
+          else
+            echo "max-parallel=10" >> $GITHUB_OUTPUT
+        shell: bash
+        
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
 
@@ -43,7 +56,7 @@ jobs:
 
           # An approximation of the PHS RStudio setup on the Posit Workbench
           - {os: ubuntu-latest, r: '4.4.2'}
-      max-parallel: ${{ env.MAX_PARALLEL }}
+      max-parallel: ${{ needs.set-max-parallel.outputs.max-parallel }}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/phs_R-CMD-check.yaml
+++ b/.github/workflows/phs_R-CMD-check.yaml
@@ -2,33 +2,13 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   workflow_call:
-    inputs:
-      limit_parallel:
-        required: false
-        type: boolean
-        default: false
-        description: "Limit concurrent jobs for this workflow to 3 (default: false)"
-
+  
 name: R-CMD-check.yaml
 
 permissions: 
   contents: read
   
-jobs:
-  set-max-parallel:
-    runs-on: ubuntu-latest
-    outputs:
-      max-parallel: ${{ steps.set-max-parallel.outputs.max-parallel }}
-    steps:
-      - id: set-max-parallel
-        run: |
-          if [ "${{ inputs.limit_parallel }}" == "true" ]; then
-            echo "max-parallel=3" >> $GITHUB_OUTPUT
-          else
-            echo "max-parallel=10" >> $GITHUB_OUTPUT
-          fi
-        shell: bash
-        
+jobs:      
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
 
@@ -54,7 +34,6 @@ jobs:
 
           # An approximation of the PHS RStudio setup on the Posit Workbench
           - {os: ubuntu-latest, r: '4.4.2'}
-      max-parallel: ${{ needs.set-max-parallel.outputs.max-parallel }}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/phs_R-CMD-check.yaml
+++ b/.github/workflows/phs_R-CMD-check.yaml
@@ -2,6 +2,12 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   workflow_call:
+    inputs:
+      limit_parallel:
+        required: false
+        type: boolean
+        default: false
+        description: "Limit concurrent jobs for this workflow to 3 (default: false)"
 
 name: R-CMD-check.yaml
 
@@ -34,6 +40,8 @@ jobs:
 
           # An approximation of the PHS RStudio setup on the Posit Workbench
           - {os: ubuntu-latest, r: '4.4.2'}
+      ${{ if inputs.limit_parallel == true }}:
+        max-parallel: 3
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/phs_R-CMD-check.yaml
+++ b/.github/workflows/phs_R-CMD-check.yaml
@@ -40,7 +40,7 @@ jobs:
 
           # An approximation of the PHS RStudio setup on the Posit Workbench
           - {os: ubuntu-latest, r: '4.4.2'}
-        max-parallel: ${{ inputs.limit_parallel == true && 3 || null }}
+        max-parallel: ${{ inputs.limit_parallel == true && 3 || 10 }}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/phs_R-CMD-check.yaml
+++ b/.github/workflows/phs_R-CMD-check.yaml
@@ -13,9 +13,6 @@ name: R-CMD-check.yaml
 
 permissions: 
   contents: read
-
-env:
-  MAX_PARALLEL:  ${{ inputs.limit_parallel == false &&  10 || 3 }}
   
 jobs:
   set-max-parallel:
@@ -29,6 +26,7 @@ jobs:
             echo "max-parallel=3" >> $GITHUB_OUTPUT
           else
             echo "max-parallel=10" >> $GITHUB_OUTPUT
+          fi
         shell: bash
         
   R-CMD-check:

--- a/.github/workflows/phs_R-CMD-check.yaml
+++ b/.github/workflows/phs_R-CMD-check.yaml
@@ -14,6 +14,9 @@ name: R-CMD-check.yaml
 permissions: 
   contents: read
 
+env:
+  MAX_PARALLEL:  ${{ inputs.limit_parallel == false &&  10 || 3 }}
+  
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
@@ -40,13 +43,13 @@ jobs:
 
           # An approximation of the PHS RStudio setup on the Posit Workbench
           - {os: ubuntu-latest, r: '4.4.2'}
-        max-parallel: ${{ inputs.limit_parallel == true && 3 || 10 }}
+      max-parallel: ${{ env.MAX_PARALLEL }}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
 
-    steps:
+    steps:    
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: r-lib/actions/setup-pandoc@14a7e741c1cb130261263aa1593718ba42cf443b # v2.11.2

--- a/.github/workflows/phs_package_checks.yaml
+++ b/.github/workflows/phs_package_checks.yaml
@@ -31,8 +31,6 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
-    with:
-      limit_parallel: ${{ inputs.limit_parallel }}
     concurrency:
       group: ${{ inputs.limit_parallel == false && format('r-cmd-check-{0}-{1}', github.workflow, github.run_id) || 'package-checks-queue' }}
       cancel-in-progress: false

--- a/.github/workflows/phs_package_checks.yaml
+++ b/.github/workflows/phs_package_checks.yaml
@@ -8,25 +8,32 @@ name: phs_package_checks.yaml
 permissions:
   contents: read
   pull-requests: read
-
+  
 jobs:
-   Style_and_document:
+  Style_and_document:
     uses: ./.github/workflows/phs_style_and_document.yaml
     permissions:
       contents: write
       pull-requests: write
     secrets: inherit
-   
-   R-CMD-check:
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+  R-CMD-check:
     needs: [Style_and_document]
     uses: ./.github/workflows/phs_R-CMD-check.yaml
-    permissions: 
+    permissions:
       contents: read
     secrets: inherit
-
-   test-coverage:
+    concurrency:
+      group: package-checks-queue
+      cancel-in-progress: false
+  test-coverage:
     needs: [R-CMD-check]
     uses: ./.github/workflows/phs_test_coverage.yaml
-    permissions: 
+    permissions:
       contents: read
     secrets: inherit
+    concurrency:
+      group: package-checks-queue
+      cancel-in-progress: false

--- a/.github/workflows/phs_package_checks.yaml
+++ b/.github/workflows/phs_package_checks.yaml
@@ -2,6 +2,12 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   workflow_call:
+    inputs:
+      limit_parallel:
+        required: false
+        type: boolean
+        default: false
+        description: "Limit concurrent jobs in general and specifically limit R-CMD-check to 3 in parallel (default: false)"
 
 name: phs_package_checks.yaml
 
@@ -25,8 +31,10 @@ jobs:
     permissions:
       contents: read
     secrets: inherit
+    with:
+      limit_parallel: ${{ inputs.limit_parallel }}
     concurrency:
-      group: package-checks-queue
+      group: ${{ inputs.limit_parallel == false && format('r-cmd-check-{0}-{1}', github.workflow, github.run_id) || 'package-checks-queue' }}
       cancel-in-progress: false
   test-coverage:
     needs: [R-CMD-check]
@@ -35,5 +43,5 @@ jobs:
       contents: read
     secrets: inherit
     concurrency:
-      group: package-checks-queue
+      group: ${{ inputs.limit_parallel == false && format('test-coverage-{0}-{1}', github.workflow, github.run_id) || 'package-checks-queue' }}
       cancel-in-progress: false


### PR DESCRIPTION
This now will cancel any ongoing 'style_and_document' job when another one starts. This should reduce the number of unnecessary jobs when multiple commits are made in quick succession.

There is also now an option `limit_parallel` which isn't required and is `false` by default, if it's set to `true` it will force any R-CMD-CHECK or test-coverage jobs to queue up. The aim here is to limit the number of tests running simultaneously which is useful when they call an API etc, that might not handle multiple simultaneous requests well.

To use the new argument `phs_checks.yaml` should be updated as below:

```yaml
jobs:
  PHS-checks:
    uses: Public-Health-Scotland/actions/.github/workflows/phs_package_checks.yaml@v1.5.0
    with:
      limit_parallel: true
    permissions: 
      contents: write
      pull-requests: write
    secrets: inherit
```