### PR TITLE
Add a noSuggests check

### DIFF
--- a/.github/workflows/phs_R-CMD-check.yaml
+++ b/.github/workflows/phs_R-CMD-check.yaml
@@ -59,3 +59,38 @@ jobs:
         with:
           upload-snapshots: true
           build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
+
+  check-no-suggests:
+    runs-on: ubuntu-latest
+    
+    name: Check noSuggests for ubuntu-latest (release)
+    
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: r-lib/actions/setup-pandoc@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 # v2.11.3
+
+      - uses: r-lib/actions/setup-r@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 # v2.11.3
+        with:
+          r-version: release
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 # v2.11.3
+        with:
+          dependencies: '"hard"'
+          cache: false
+          extra-packages: |
+            any::rcmdcheck
+            any::testthat
+            any::knitr
+            any::rmarkdown
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 # v2.11.3
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/phs_R-CMD-check.yaml
+++ b/.github/workflows/phs_R-CMD-check.yaml
@@ -81,7 +81,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 # v2.11.3
         with:
-          dependencies: '"hard"'
+          dependencies: 'hard'
           cache: false
           extra-packages: |
             any::rcmdcheck


### PR DESCRIPTION
This is important for CRAN submissions, as it ensures the package runs properly by passing checks and tests with only the necessary dependencies. This is one of the evaluations that CRAN will perform.