### PR TITLE
Add job status

### DIFF
--- a/.github/workflows/phs_package_checks.yaml
+++ b/.github/workflows/phs_package_checks.yaml
@@ -14,7 +14,7 @@ name: phs_package_checks.yaml
 permissions:
   contents: read
   pull-requests: read
-  statuses: read
+  statuses: write
   
 jobs:
   # Initial job to post status


### PR DESCRIPTION
**NOTE** To make use of this, you will need to update the permissions of the `phs_checks.yaml` action. Adding `statuses: read` to the 'top-level' permissions block and `statuses: write` to the job permission block.

```yaml
on:
  push:
    branches: [main, master]
  pull_request:
    branches: [main, master]
  workflow_dispatch:

name: phs_checks.yaml

permissions: 
  contents: read
  pull-requests: read
  statuses: read

jobs:
  PHS-checks:
    uses: Public-Health-Scotland/actions/.github/workflows/phs_package_checks.yaml@job-status
    permissions: 
      contents: write
      pull-requests: write
      statuses: write
    secrets: inherit
```

This pull request updates the GitHub Actions workflow for package checks by adding jobs to create and finalise a commit status for the overall package checks. This provides clearer feedback on the status of all checks directly in the commit status, making it easier to track progress and results.

**Workflow status enhancements:**

* Added an `init` job to set a pending commit status at the start of the workflow, indicating that package checks are in progress.
* Added a `finalise` job that updates the commit status to success or failure based on the results of all package check jobs, giving a clear summary of the outcome.