### PR TITLE
Only run pkgdown on pushes to main/master

### DIFF
--- a/.github/workflows/phs_package_checks.yaml
+++ b/.github/workflows/phs_package_checks.yaml
@@ -73,6 +73,7 @@ jobs:
       cancel-in-progress: false
   pkgdown:
     needs: [Style_and_document]
+    if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (github.ref_name == 'main' || github.ref_name == 'master') }}
     uses: ./.github/workflows/phs_pkgdown.yaml
     permissions:
       contents: write
@@ -92,7 +93,8 @@ jobs:
             const allSuccess = ${{ needs.Style_and_document.result == 'success' && 
                                     needs.R-CMD-check-core.result == 'success' && 
                                     needs.test-coverage.result == 'success' && 
-                                    needs.pkgdown.result == 'success' }};
+                                    (needs.pkgdown.result == 'success' || needs.pkgdown.result == 'skipped')
+                                    }};
             
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,

--- a/.github/workflows/phs_package_checks.yaml
+++ b/.github/workflows/phs_package_checks.yaml
@@ -72,7 +72,11 @@ jobs:
       group: ${{ inputs.limit_parallel == false && format('test-coverage-{0}-{1}', github.workflow, github.run_id) || 'package-checks-queue' }}
       cancel-in-progress: false
   pkgdown:
-    needs: [Style_and_document]
+    needs:
+      - Style_and_document
+      - R-CMD-check-core
+      - R-CMD-check-extended
+      - test-coverage
     if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (github.ref_name == 'main' || github.ref_name == 'master') }}
     uses: ./.github/workflows/phs_pkgdown.yaml
     permissions:


### PR DESCRIPTION
On a PR, there's no need for this job to run, so it will be skipped.