### PR TITLE
Skip R-CMD-check-extended faster on Draft PRs

### DIFF
--- a/.github/workflows/phs_R-CMD-check-extended.yaml
+++ b/.github/workflows/phs_R-CMD-check-extended.yaml
@@ -10,7 +10,6 @@ permissions:
 
 jobs:
   R-CMD-check-extended:
-    if: ${{ !github.event.pull_request.draft }}
     runs-on: ${{ matrix.config.os }}
     name: Extended R-CMD-check – ${{ matrix.config.os }} (${{ matrix.config.r }})
     strategy:

--- a/.github/workflows/phs_package_checks.yaml
+++ b/.github/workflows/phs_package_checks.yaml
@@ -54,7 +54,7 @@ jobs:
       group: ${{ inputs.limit_parallel == false && format('r-cmd-check-{0}-{1}', github.workflow, github.run_id) || 'phs-core-check-queue' }}
       cancel-in-progress: false
   R-CMD-check-extended:
-    needs: [R-CMD-check-core]
+    needs: [Style_and_document]
     if: ${{ !github.event.pull_request.draft }}
     uses: ./.github/workflows/phs_R-CMD-check-extended.yaml
     permissions:
@@ -85,7 +85,12 @@ jobs:
     secrets: inherit
 # Final job to update status
   finalize:
-    needs: [Style_and_document, R-CMD-check-core, test-coverage, pkgdown]
+    needs:
+      - Style_and_document
+      - R-CMD-check-core
+      - R-CMD-check-extended
+      - test-coverage
+      - pkgdown
     runs-on: ubuntu-latest
     if: always()
     permissions:

--- a/.github/workflows/phs_package_checks.yaml
+++ b/.github/workflows/phs_package_checks.yaml
@@ -55,6 +55,7 @@ jobs:
       cancel-in-progress: false
   R-CMD-check-extended:
     needs: [R-CMD-check-core]
+    if: ${{ !github.event.pull_request.draft }}
     uses: ./.github/workflows/phs_R-CMD-check-extended.yaml
     permissions:
       contents: read
@@ -96,6 +97,7 @@ jobs:
           script: |
             const allSuccess = ${{ needs.Style_and_document.result == 'success' && 
                                     needs.R-CMD-check-core.result == 'success' && 
+                                    (needs.R-CMD-check-extended.result == 'success' || needs.R-CMD-check-extended.result == 'skipped') &&
                                     needs.test-coverage.result == 'success' && 
                                     (needs.pkgdown.result == 'success' || needs.pkgdown.result == 'skipped')
                                     }};


### PR DESCRIPTION
I also included it in the 'final check' so if it fails, the overall workflow will fail.