### PR TITLE
Add using PHS_ACTIONS_TOKEN to allow restarting workflows after an auto-commit

### DIFF
--- a/.github/workflows/phs_build_readme.yaml
+++ b/.github/workflows/phs_build_readme.yaml
@@ -24,7 +24,7 @@ jobs:
       pull-requests: write
 
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_PAT: ${{ secrets.PHS_ACTIONS_TOKEN || github.token }}
 
     steps:
       - name: Install git
@@ -40,6 +40,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+          token: ${{ secrets.PHS_ACTIONS_TOKEN || github.token }}
       
       - name: Determine whether README needs rebuilding
         id: readme-check
@@ -112,6 +113,7 @@ jobs:
         if: ${{ steps.readme-check.outputs.build == 'true' && steps.commit_step_readme.outputs.changes_detected == 'true' && steps.commit_step_readme.outcome == 'failure' }}
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          token: ${{ secrets.PHS_ACTIONS_TOKEN || github.token }}
           commit-message: "Build README (GHA)"
           branch: auto-build-readme
           delete-branch: true

--- a/.github/workflows/phs_build_readme.yaml
+++ b/.github/workflows/phs_build_readme.yaml
@@ -2,6 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   workflow_call:
+    secrets:
+      PHS_ACTIONS_TOKEN:
+        required: false
 
 name: phs_build_readme.yaml
 

--- a/.github/workflows/phs_package_checks.yaml
+++ b/.github/workflows/phs_package_checks.yaml
@@ -8,6 +8,9 @@ on:
         type: boolean
         default: false
         description: "Limit concurrent jobs in general and specifically limit R-CMD-check to 3 in parallel (default: false)"
+    secrets:
+      PHS_ACTIONS_TOKEN:
+        required: false
 
 name: phs_package_checks.yaml
 

--- a/.github/workflows/phs_package_checks.yaml
+++ b/.github/workflows/phs_package_checks.yaml
@@ -18,6 +18,10 @@ permissions:
   contents: read
   pull-requests: read
   statuses: read
+
+concurrency:
+  group: ${{ format('phs-package-checks-{0}-{1}', github.repository, github.event.pull_request.number || github.ref) }}
+  cancel-in-progress: true
   
 jobs:
   # Initial job to post status

--- a/.github/workflows/phs_style_and_document.yaml
+++ b/.github/workflows/phs_style_and_document.yaml
@@ -2,6 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   workflow_call:
+    secrets:
+      PHS_ACTIONS_TOKEN:
+        required: false
 
 name: phs_style_and_document.yaml
 

--- a/.github/workflows/phs_style_and_document.yaml
+++ b/.github/workflows/phs_style_and_document.yaml
@@ -24,7 +24,7 @@ jobs:
       pull-requests: write
       
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_PAT: ${{ secrets.PHS_ACTIONS_TOKEN || github.token }}
       
     steps:
       - name: Install git
@@ -40,6 +40,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+          token: ${{ secrets.PHS_ACTIONS_TOKEN || github.token }}
 
       - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
@@ -125,8 +126,8 @@ jobs:
         if: ${{ steps.commit_step_document.outputs.changes_detected == 'true' && steps.commit_step_document.outcome == 'failure' }}
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          token: ${{ secrets.PHS_ACTIONS_TOKEN || github.token }}
           commit-message: "Document package (GHA)"
-          # Use a different branch name than the style PR
           branch: auto-document-code
           delete-branch: true
           title: "Document package (GHA)"


### PR DESCRIPTION
This PR updates the PHS package checks workflow to use workflow-level concurrency by default, so newer runs for the same pull request or branch cancel any older in-progress runs. This is particularly useful where the workflow makes automated commits, as the follow-up run checks out the latest commit rather than continuing to run checks against an outdated revision.

To make it possible for follow-up runs to be triggered by auto-commits a repository secret must be added `PHS_ACTIONS_TOKEN` with permissions:
 - Contents: Read and write
 - Pull requests: Read and write

I will try to get a token created and added at the org level to make this easier.
